### PR TITLE
Set `process.title` during init and configUpdated

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 
 	async init(config: ModuleConfig): Promise<void> {
 		this.config = config
+		process.title = this.label
 
 		this.updateStatus(InstanceStatus.Ok)
 
@@ -28,6 +29,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 
 	async configUpdated(config: ModuleConfig): Promise<void> {
 		this.config = config
+		process.title = this.label
 	}
 
 	// Return config fields for web config


### PR DESCRIPTION
Set process title during `init` and `configUpdated` for easier debugging and tracing unexpectedly high resource usage.

This complements the logging of PIDs added in `3.5.5`, but is more user friendly.

Ie, looking at `top` under Ubuntu:

![image](https://github.com/user-attachments/assets/c261e8a5-1954-4518-9327-39f8c6fd140e)
