### PR TITLE
Add missing "@types/jest" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"devDependencies": {
 		"@companion-module/tools": "^2.3.0",
 		"@types/node": "^22.14.1",
+		"@types/jest": "^30.0.0",
 		"eslint": "^9.24.0",
 		"husky": "^9.1.7",
 		"lint-staged": "^15.5.1",


### PR DESCRIPTION
Results in a warning/error in VS Code:
>Cannot find type definition file for 'jest'.
>  The file is in the program because:
>    Entry point of type library 'jest' specified in compilerOptions