### PR TITLE
Add code to automatically fill in missing config fields.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,24 @@ export interface ModuleConfig {
 	port: number
 }
 
+const defaultConfig: ModuleConfig = {
+	host: '',
+	port: 8000,
+}
+
+export function updateConfig(config: ModuleConfig): boolean {
+	let updated = false
+	for (const key in defaultConfig) {
+		if (!(key in config)) {
+			// a bit of contortion to get past TypeScript errors: "expression of type 'string' can't be used to index type 'ModuleConfig'."
+			const obj = { [key]: defaultConfig[key as keyof ModuleConfig] }
+			Object.assign(config, obj)
+			updated = true
+		}
+	}
+	return updated
+}
+
 export function GetConfigFields(): SomeCompanionConfigField[] {
 	return [
 		{
@@ -21,7 +39,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			width: 4,
 			min: 1,
 			max: 65535,
-			default: 8000,
+			default: defaultConfig.port,
 		},
 	]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { InstanceBase, runEntrypoint, InstanceStatus, SomeCompanionConfigField } from '@companion-module/base'
-import { GetConfigFields, type ModuleConfig } from './config.js'
+import { GetConfigFields, updateConfig, type ModuleConfig } from './config.js'
 import { UpdateVariableDefinitions } from './variables.js'
 import { UpgradeScripts } from './upgrades.js'
 import { UpdateActions } from './actions.js'
@@ -27,6 +27,11 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 	}
 
 	async configUpdated(config: ModuleConfig): Promise<void> {
+		// first make sure the config is complete (i.e. auto-update for new config features)
+		if (updateConfig(config)) {
+			//console.log('Adding missing config properties')
+			this.saveConfig(config)
+		}
 		this.config = config
 	}
 


### PR DESCRIPTION
I'm sharing this just in case  you feel it is of general interest... (a similar change could be ported to the js template too)

This code has the potential to reduce or even eliminate the need for a config update script... and definitely made it simpler for me as a developer to make incremental changes to the config definition without causing the module to crash when loading. (Note that calls to `updateConfig` are rare enough that this essentially adds no overhead.)