### PR TITLE
Add a `@schema` property to `companion/manifest.json`, referring to the schema location populated upon `yarn install`

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "../node_modules/@companion-module/base/assets/manifest.schema.json",
 	"id": "your-module-name",
 	"name": "your-module-name",
 	"shortname": "module-shortname",


### PR DESCRIPTION
I presume here that it's not gauche to refer to a location that only gets populated after dependency installation.